### PR TITLE
suggestion to fix small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# fk_tournement_planer
+# fk_tournament_planer
 
-A web app for planning and running sport tournements. Currently fokus is on [ddc](https://de.wikipedia.org/wiki/Double_Disc_Court) tournements, but fk_tournement_planer will be generic for everyone and every sport to use.
+A web app for planning and running sport tournaments. Currently fokus is on [ddc](https://de.wikipedia.org/wiki/Double_Disc_Court) tournements, but fk_tournament_planer will be generic for everyone and every sport to use.


### PR DESCRIPTION
"Turnier" in German should be "Tournament" in English, see https://www.linguee.de/englisch-deutsch/uebersetzung/tournament.html